### PR TITLE
feat: Add ExecuteCommand action in component template

### DIFF
--- a/component/template/src/action.rs
+++ b/component/template/src/action.rs
@@ -6,6 +6,9 @@ use serde::{
 };
 use strum::Display;
 
+type Command = String;
+type CommandArgs = Vec<String>;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Display, Deserialize)]
 pub enum Action {
   Tick,
@@ -17,4 +20,5 @@ pub enum Action {
   ClearScreen,
   Error(String),
   Help,
+  ExecuteCommand(Command, CommandArgs),
 }

--- a/component/template/src/app.rs
+++ b/component/template/src/app.rs
@@ -127,6 +127,14 @@ impl App {
               }
             })?;
           },
+          Action::ExecuteCommand(ref command, ref args) => {
+            tui.exit()?;
+            let cmd = command.to_string();
+            let cmd_args = args.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
+            self.spawn_process(&cmd, &cmd_args)?;
+            tui.enter()?;
+            action_tx.send(Action::ClearScreen)?;
+          }
           _ => {},
         }
         for component in self.components.iter_mut() {
@@ -148,5 +156,13 @@ impl App {
     }
     tui.exit()?;
     Ok(())
+  }
+
+  fn spawn_process(&self, command: &str, args: &[&str]) -> Result<()> {
+      let status = std::process::Command::new(command).args(args).status()?;
+      if !status.success() {
+        eprintln!("\nCommand failed with status: {}", status);
+      }
+      Ok(())
   }
 }

--- a/component/template/src/components/home.rs
+++ b/component/template/src/components/home.rs
@@ -35,6 +35,18 @@ impl Component for Home {
     Ok(())
   }
 
+  fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<Action>> {
+    match key.code {
+      KeyCode::Char('e') => {
+        let cmd = String::from("vim");
+        let cmd_args = vec!["/tmp/a.txt".into()];
+        let action = Action::ExecuteCommand(cmd, cmd_args);
+        Ok(Some(action))
+      }
+      _ => Ok(None)
+    }
+  }
+
   fn update(&mut self, action: Action) -> Result<Option<Action>> {
     match action {
       Action::Tick => {
@@ -45,7 +57,7 @@ impl Component for Home {
   }
 
   fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
-    f.render_widget(Paragraph::new("hello world"), area);
+    f.render_widget(Paragraph::new("Hello world, press 'e' to edit /tmp/a.txt with vim"), area);
     Ok(())
   }
 }


### PR DESCRIPTION
## Description

Adds `Action::ExecuteCommand` in component template to demonstrate spawning child processes from tui. This PR is related to this thread https://github.com/ratatui-org/ratatui-website/pull/651#discussion_r1663028327

The goal is to add this functionality directly to component template so that we can demonstrate 
> pausing the key event handler before spawning vim and restarting the key event handler after resuming from vim exiting
and link to this feature from ratatui docs on How to spawn vim (https://github.com/ratatui-org/ratatui-website/pull/651)

I am not sure if this is out of scope for the component template. Any feedback is appreciated!! Thanks!