### PR TITLE
Feat(component): Add a mean for components to access raw key events

### DIFF
--- a/component-generated/src/action.rs
+++ b/component-generated/src/action.rs
@@ -1,3 +1,4 @@
+use crossterm::event::KeyEvent;
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -8,6 +9,7 @@ pub enum Action {
     Resize(u16, u16),
     Suspend,
     Resume,
+    RawKeyEvent(KeyEvent),
     Quit,
     ClearScreen,
     Error(String),

--- a/component-generated/src/app.rs
+++ b/component-generated/src/app.rs
@@ -110,6 +110,10 @@ impl App {
         let Some(keymap) = self.config.keybindings.get(&self.mode) else {
             return Ok(());
         };
+        if self.components.iter().any(|c| c.is_editing()) {
+            action_tx.send(Action::RawKeyEvent(key))?;
+            return Ok(());
+        }
         match keymap.get(&vec![key]) {
             Some(action) => {
                 info!("Got action: {action:?}");

--- a/component-generated/src/components.rs
+++ b/component-generated/src/components.rs
@@ -55,6 +55,13 @@ pub trait Component {
         let _ = area; // to appease clippy
         Ok(())
     }
+    /// Whether the app should send `Action::RawKeyEvent` or the corresponding `Action` variant.
+    ///
+    /// # Returns
+    /// * `bool` - Whether the component is waiting only for raw key events actions or not.
+    fn is_editing(&self) -> bool {
+        false
+    }
     /// Handle incoming events and produce actions if necessary.
     ///
     /// # Arguments

--- a/component/template/src/action.rs
+++ b/component/template/src/action.rs
@@ -1,3 +1,4 @@
+use crossterm::event::KeyEvent;
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
@@ -8,6 +9,7 @@ pub enum Action {
     Resize(u16, u16),
     Suspend,
     Resume,
+    RawKeyEvent(KeyEvent),
     Quit,
     ClearScreen,
     Error(String),

--- a/component/template/src/app.rs
+++ b/component/template/src/app.rs
@@ -110,6 +110,10 @@ impl App {
         let Some(keymap) = self.config.keybindings.get(&self.mode) else {
             return Ok(());
         };
+        if self.components.iter().any(|c| c.is_editing()) {
+            action_tx.send(Action::RawKeyEvent(key))?;
+            return Ok(());
+        }
         match keymap.get(&vec![key]) {
             Some(action) => {
                 info!("Got action: {action:?}");

--- a/component/template/src/components.rs
+++ b/component/template/src/components.rs
@@ -55,6 +55,13 @@ pub trait Component {
         let _ = area; // to appease clippy
         Ok(())
     }
+    /// Whether the app should send `Action::RawKeyEvent` or the corresponding `Action` variant.
+    ///
+    /// # Returns
+    /// * `bool` - Whether the component is waiting only for raw key events actions or not.
+    fn is_editing(&self) -> bool {
+        false
+    }
     /// Handle incoming events and produce actions if necessary.
     ///
     /// # Arguments


### PR DESCRIPTION
# Description
This adds an `is_editing` method to components for whether they should receive all key inputs or just the regular actions.

# Why
Currently, there is no way for a component to take user input.