### PR TITLE
fix: rename LOGLEVEL to LOG_LEVEL

### DIFF
--- a/component-generated/src/logging.rs
+++ b/component-generated/src/logging.rs
@@ -5,7 +5,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use crate::config;
 
 lazy_static::lazy_static! {
-    pub static ref LOG_ENV: String = format!("{}_LOGLEVEL", config::PROJECT_NAME.clone());
+    pub static ref LOG_ENV: String = format!("{}_LOG_LEVEL", config::PROJECT_NAME.clone());
     pub static ref LOG_FILE: String = format!("{}.log", env!("CARGO_PKG_NAME"));
 }
 

--- a/component/template/.envrc
+++ b/component/template/.envrc
@@ -1,3 +1,3 @@
 export {{crate_name | shouty_snake_case}}_CONFIG=`pwd`/.config
 export {{crate_name | shouty_snake_case}}_DATA=`pwd`/.data
-export {{crate_name | shouty_snake_case}}_LOGLEVEL=debug
+export {{crate_name | shouty_snake_case}}_LOG_LEVEL=debug

--- a/component/template/.envrc
+++ b/component/template/.envrc
@@ -1,3 +1,3 @@
 export {{crate_name | shouty_snake_case}}_CONFIG=`pwd`/.config
 export {{crate_name | shouty_snake_case}}_DATA=`pwd`/.data
-export {{crate_name | shouty_snake_case}}_LOG_LEVEL=debug
+export {{crate_name | shouty_snake_case}}_LOGLEVEL=debug

--- a/component/template/src/logging.rs
+++ b/component/template/src/logging.rs
@@ -5,7 +5,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use crate::config;
 
 lazy_static::lazy_static! {
-    pub static ref LOG_ENV: String = format!("{}_LOGLEVEL", config::PROJECT_NAME.clone());
+    pub static ref LOG_ENV: String = format!("{}_LOG_LEVEL", config::PROJECT_NAME.clone());
     pub static ref LOG_FILE: String = format!("{}.log", env!("CARGO_PKG_NAME"));
 }
 


### PR DESCRIPTION
I found that when I used debug! to print logs, it always had no output. Eventually, I discovered that in the .envrc file it was LOG_LEVEL while in the code it was LOGLEVEL.