### PR TITLE
refactor: Simplify simple-async event handler

### DIFF
--- a/simple-async-generated/src/main.rs
+++ b/simple-async-generated/src/main.rs
@@ -64,25 +64,19 @@ impl App {
 
     /// Reads the crossterm events and updates the state of [`App`].
     async fn handle_crossterm_events(&mut self) -> Result<()> {
-        tokio::select! {
-            event = self.event_stream.next().fuse() => {
-                match event {
-                    Some(Ok(evt)) => {
-                        match evt {
-                            Event::Key(key)
-                                if key.kind == KeyEventKind::Press
-                                    => self.on_key_event(key),
-                            Event::Mouse(_) => {}
-                            Event::Resize(_, _) => {}
-                            _ => {}
-                        }
-                    }
+        let event = self.event_stream.next().fuse().await;
+        match event {
+            Some(Ok(evt)) => {
+                match evt {
+                    Event::Key(key)
+                        if key.kind == KeyEventKind::Press
+                            => self.on_key_event(key),
+                    Event::Mouse(_) => {}
+                    Event::Resize(_, _) => {}
                     _ => {}
                 }
             }
-            _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
-                // Sleep for a short duration to avoid busy waiting.
-            }
+            _ => {}
         }
         Ok(())
     }

--- a/simple-async/template/src/main.rs
+++ b/simple-async/template/src/main.rs
@@ -64,25 +64,19 @@ impl App {
 
     /// Reads the crossterm events and updates the state of [`App`].
     async fn handle_crossterm_events(&mut self) -> Result<()> {
-        tokio::select! {
-            event = self.event_stream.next().fuse() => {
-                match event {
-                    Some(Ok(evt)) => {
-                        match evt {
-                            Event::Key(key)
-                                if key.kind == KeyEventKind::Press
-                                    => self.on_key_event(key),
-                            Event::Mouse(_) => {}
-                            Event::Resize(_, _) => {}
-                            _ => {}
-                        }
-                    }
+        let event = self.event_stream.next().fuse().await;
+        match event {
+            Some(Ok(evt)) => {
+                match evt {
+                    Event::Key(key)
+                        if key.kind == KeyEventKind::Press
+                            => self.on_key_event(key),
+                    Event::Mouse(_) => {}
+                    Event::Resize(_, _) => {}
                     _ => {}
                 }
             }
-            _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
-                // Sleep for a short duration to avoid busy waiting.
-            }
+            _ => {}
         }
         Ok(())
     }


### PR DESCRIPTION
When I was reading the simple-async template as a new user, I was initially confused by the sleep that caused renders when none were actually needed. After diving into ratatui further I now understand that a steady render 'tick' could be useful for interfaces that display things like a clock, a timer, or any other information that is changed continually without the presence of events.

I propose to simplify this template to not include the automatic re-render, to make the working of the async event loop easier to understand for new users. Or alternatively (not this PR) we could perhaps include a comment block that explains the use for a recurring render? My preference though is to keep it simple which is why I made this PR; but don't hesitate to close if it's unwanted :) (Also, I'm still very new to ratatui so I may be totally missing a reason for the sleep to be there).