### PR TITLE
ci: Allow reading content for clippy checkout step

### DIFF
--- a/simple/template/.github/workflows/ci.yml
+++ b/simple/template/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       checks: write
     steps:
       - name: Checkout


### PR DESCRIPTION
Fix: #109 

I added the `contents: read` permission specifically for the Clippy job. Now, the CI workflow runs all successfully even with the repository set to private.
