### PR TITLE
feat: add recommended optimization options to Ratatui templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
 [workspace]
+members = [
+    "*-generated",
+]
 resolver = "2"
-members = ["*-generated"]

--- a/component-generated/Cargo.toml
+++ b/component-generated/Cargo.toml
@@ -45,3 +45,10 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "serde"] }
 [build-dependencies]
 anyhow = "1.0.90"
 vergen-gix = { version = "1.0.2", features = ["build", "cargo"] }
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/component/template/Cargo.toml
+++ b/component/template/Cargo.toml
@@ -47,3 +47,10 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "serde"] }
 [build-dependencies]
 anyhow = "1.0.90"
 vergen-gix = { version = "1.0.2", features = ["build", "cargo"] }
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/event-driven-async-generated/Cargo.toml
+++ b/event-driven-async-generated/Cargo.toml
@@ -12,3 +12,10 @@ futures = "0.3.31"
 ratatui = "0.29.0"
 tokio = { version = "1.40.0", features = ["full"] }
 color-eyre = "0.6.3"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/event-driven-async/template/Cargo.toml
+++ b/event-driven-async/template/Cargo.toml
@@ -12,3 +12,10 @@ futures = "0.3.31"
 ratatui = "0.29.0"
 tokio = { version = "1.40.0", features = ["full"] }
 color-eyre = "0.6.3"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/event-driven-generated/Cargo.toml
+++ b/event-driven-generated/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2024"
 crossterm = "0.28.1"
 ratatui = "0.29.0"
 color-eyre = "0.6.3"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/event-driven/template/Cargo.toml
+++ b/event-driven/template/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2024"
 crossterm = "0.28.1"
 ratatui = "0.29.0"
 color-eyre = "0.6.3"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/hello-world-generated/Cargo.toml
+++ b/hello-world-generated/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2024"
 color-eyre = "0.6.3"
 crossterm = "0.28.1"
 ratatui = "0.29.0"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/hello-world/template/Cargo.toml
+++ b/hello-world/template/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2024"
 color-eyre = "0.6.3"
 crossterm = "0.28.1"
 ratatui = "0.29.0"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/simple-async-generated/Cargo.toml
+++ b/simple-async-generated/Cargo.toml
@@ -12,3 +12,10 @@ crossterm = { version = "0.28.1", features = ["event-stream"] }
 futures = "0.3.31"
 ratatui = "0.29.0"
 tokio = { version = "1.40.0", features = ["full"] }
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/simple-async/template/Cargo.toml
+++ b/simple-async/template/Cargo.toml
@@ -12,3 +12,10 @@ crossterm = { version = "0.28.1", features = ["event-stream"] }
 futures = "0.3.31"
 ratatui = "0.29.0"
 tokio = { version = "1.40.0", features = ["full"] }
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/simple-generated/Cargo.toml
+++ b/simple-generated/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2024"
 crossterm = "0.28.1"
 ratatui = "0.29.0"
 color-eyre = "0.6.3"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+

--- a/simple/template/Cargo.toml
+++ b/simple/template/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2024"
 crossterm = "0.28.1"
 ratatui = "0.29.0"
 color-eyre = "0.6.3"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true
+


### PR DESCRIPTION
Partially resolves https://github.com/ratatui/ratatui/discussions/2072

This is a second part about introducing new optimization options to Ratatui users. In this PR we apply the recommended settings to Ratatui templates for `cargo-generate` so users will get the recommended options "automatically" when a new Ratatui app will be created via `cargo-generate`.